### PR TITLE
Updated addthis displays

### DIFF
--- a/addthis_displays/addthis_displays.addthis.inc
+++ b/addthis_displays/addthis_displays.addthis.inc
@@ -61,6 +61,13 @@ function addthis_displays_addthis_display_markup__addthis_basic_toolbox($options
     //   You can't add this bubble style now.
     $orientation = ($options['#display']['settings']['counter_orientation'] == 'horizontal' ? TRUE : FALSE);
     switch ($service) {
+      case 'addthis':
+        $items[$service]['#attributes'] = array(
+            'class' => array(
+              'addthis_counter addthis_pill_style'
+            )
+        );
+        break;  
       case 'facebook_like':
         $items[$service]['#attributes'] += array(
           'fb:like:layout' => ($orientation ? 'button_count' : 'box_count')
@@ -68,7 +75,7 @@ function addthis_displays_addthis_display_markup__addthis_basic_toolbox($options
         break;
       case 'google_plusone':
         $items[$service]['#attributes'] += array(
-          'g:plusone:size' => ($orientation ? 'standard' : 'tall')
+          'g:plusone:size' => ($orientation ? 'medium' : 'tall')
         );
         break;
       case 'tweet':

--- a/addthis_displays/addthis_displays.addthis.inc
+++ b/addthis_displays/addthis_displays.addthis.inc
@@ -59,6 +59,9 @@ function addthis_displays_addthis_display_markup__addthis_basic_toolbox($options
     // @todo Fix a way to use addthis_bubble_style.
     //   There is a conflict now with using the class addthis_button_[service].
     //   You can't add this bubble style now.
+    // $options['#display']['settings']['buttons_size']
+    $buttonbig = ($options['#display']['settings']['buttons_size'] == AddThis::CSS_32x32 ? TRUE : FALSE);
+    $bubblecounts = ($options['#display']['settings']['counter_enabled'] == 'true' ? TRUE : FALSE);
     $orientation = ($options['#display']['settings']['counter_orientation'] == 'horizontal' ? TRUE : FALSE);
     switch ($service) {
       case 'addthis':
@@ -74,13 +77,19 @@ function addthis_displays_addthis_display_markup__addthis_basic_toolbox($options
         );
         break;
       case 'google_plusone':
+        //TODO Integrate annotation & size options.
         $items[$service]['#attributes'] += array(
-          'g:plusone:size' => ($orientation ? 'medium' : 'tall')
+          'g:plusone:size' => ($buttonbig ? 'tall' : 'medium'),
+          //('small' : 'medium' : 'standard' : 'tall')
+          'g:plusone:annotation' => ($bubblecounts ? 'bubble' : 'none')
+          //( 'none' : 'inline' : 'bubble')
         );
         break;
       case 'tweet':
         $items[$service]['#attributes'] += array(
-          'tw:count' => ($orientation ? 'horizontal' : 'vertical'),
+          //TODO Integrate count options.
+          'tw:count' => ($bubblecounts ? ($orientation ? 'horizontal' : 'vertical') : 'none'),
+          //($orientation ? 'none' : 'horizontal' : 'vertical'),
           'tw:via' => AddThis::getInstance()->getTwitterVia(),
         );
         break;

--- a/addthis_displays/addthis_displays.field.inc
+++ b/addthis_displays/addthis_displays.field.inc
@@ -17,6 +17,7 @@ function addthis_displays_field_formatter_info() {
     'settings' => array(
       'share_services' => 'facebook,twitter',
       'buttons_size' => 'addthis_16x16_style',
+      'counter_enabled' => 'false',
       'counter_orientation' => 'horizontal',
       'extra_css' => '',
     ),
@@ -59,6 +60,16 @@ function addthis_displays_field_formatter_settings_form($field, $instance, $view
           AddThis::CSS_16x16 => t('Small (16x16)'),
           AddThis::CSS_32x32 => t('Big (32x32)'),
         ),
+      );
+      $element['counter_enabled'] = array(
+        '#title' => t('Enable button counters'),
+        '#description' => t('Enable service counters where appropriate.'),
+        '#type' => 'select',
+        '#default_value' => $settings['counter_enabled'],
+        '#options' => array(
+          'true' => t('Enable'),
+          'false' => t('Disable'),
+        )
       );
       $element['counter_orientation'] = array(
         '#title' => t('Counter orientation'),


### PR DESCRIPTION
Added an AddThis button within the services switch, this is the standard AddThis pill style button.
To get this button use the string "addthis" in the services list for the drupal field display.
Updated the Googleplus service to use the medium button so the button size fits with 16x16 buttons.

Thanks for the module, it rocks.
Enjoy!
