### PR TITLE
Changing default services for toolbox

### DIFF
--- a/addthis_displays/addthis_displays.field.inc
+++ b/addthis_displays/addthis_displays.field.inc
@@ -15,7 +15,7 @@ function addthis_displays_field_formatter_info() {
     'label' => t('Basic Toolbox'),
     'field types' => array(AddThis::FIELD_TYPE),
     'settings' => array(
-      'share_services' => 'facebook,twitter',
+      'share_services' => 'preferred_1,preferred_2,preferred_3,preferred_4,compact',
       'buttons_size' => 'addthis_16x16_style',
       'counter_orientation' => 'horizontal',
       'extra_css' => '',


### PR DESCRIPTION
Changing default services to those that will get users the most shares without any configuration -- these preferred options will populate in the services most relevant to the person on their site at the time, the more option brings in the dropdown of all 200+ social services supported by AddThis on click. These are the defaults we use in other CMS integrations.
