### PR TITLE
whitespace and logic simplification

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -4,7 +4,7 @@
 Add This module provides Drupal integration to addthis.com link sharing service.
 Integration has been implemented as a field.
 
-Description from addthis.com: 
+Description from addthis.com:
 The AddThis button spreads your content across the Web by making it easier for
 your visitors to bookmark and share it with other people, again... and again...
 and again. This simple yet powerful button is very easy to install and provides

--- a/addthis.example.php
+++ b/addthis.example.php
@@ -5,7 +5,7 @@
  */
 function hook_page_build(&$page) {
 
-  // Load the scripts on a specific url or other case when you don't use the 
+  // Load the scripts on a specific url or other case when you don't use the
   // Field API or Block.
   if (current_path() == 'node/1') {
     $manager = AddThisScriptManager::getInstance();

--- a/addthis_displays/addthis_displays.field.inc
+++ b/addthis_displays/addthis_displays.field.inc
@@ -50,7 +50,7 @@ function addthis_displays_field_formatter_settings_form($field, $instance, $view
         '#required' => TRUE,
         '#element_validate' => array('_addthis_display_element_validate_services'),
         '#description' =>
-          t('Specify the names of the sharing services and seperate them with a , (comma). <a href="http://www.addthis.com/services/list" target="_blank">The names on this list are valid.</a>') . 
+          t('Specify the names of the sharing services and seperate them with a , (comma). <a href="http://www.addthis.com/services/list" target="_blank">The names on this list are valid.</a>') .
           t('Elements that are available but not ont the services list are (!services).',
             array('!services' => 'bubble_style, pill_style, tweet, facebook_send, twitter_follow_native, google_plusone, stumbleupon_badge, counter_* (several supported services), linkedin_counter')
         ),

--- a/classes/Services/AddThisScriptManager.php
+++ b/classes/Services/AddThisScriptManager.php
@@ -77,7 +77,7 @@ class AddThisScriptManager {
   public function correctSchemaIfHttps($url) {
     if (is_string($url) && $this->isHttps()) {
       return str_replace('http://', 'https://', $url);
-    } 
+    }
     else {
       return $url;
     }

--- a/classes/Services/AddThisScriptManager.php
+++ b/classes/Services/AddThisScriptManager.php
@@ -101,7 +101,7 @@ class AddThisScriptManager {
       $widget_js = new AddThisWidgetJsUrl($this->getWidgetJsUrl());
 
       $pubid = $this->addthis->getProfileId();
-      if (isset($pubid) && !empty($pubid) && is_string($pubid)) {
+      if (!empty($pubid) && is_string($pubid)) {
         $widget_js->addAttribute('pubid', $pubid);
       }
 


### PR DESCRIPTION
Removing whitespace at the ends of lines (sorry, I have a thing for orderly whitespace) and simplifying a little bit of logic. Specifically, you don't need to check a variable with `isset` before checking with `empty`, because the implementation of `empty` does a check with `isset`.

http://php.net/manual/en/function.empty.php
