### PR TITLE
Feature/anonymous profile

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -8,6 +8,7 @@ Github merges
 
 - Issue #6 Changing default toolbox buttons on fields.
 - Issue #8 Minor fixes in whitespace and use of empty method.
+- Issue #12 Using an anonymous profile id when one isn't provided, to allow a site to get past analytics from AddThis if they sign up for an account at a later date
 
 # 7.x-4.0-alpha6
 Use update.php to rebuild the registry because of class changes.

--- a/TODO.txt
+++ b/TODO.txt
@@ -1,6 +1,5 @@
 - Add custom button with upload functionality for a custom button image.
 - Move basic button to main module to provide a basic implementation.
-- Create asynchronous load checkbox in settings page.
 - Refactor the order of methods in the AddThis class to collect same type of methods.
 - Refactor the rendering into classes per display type.
 - Delegate settings save validation to it corresponding display type class.

--- a/classes/AddThis.php
+++ b/classes/AddThis.php
@@ -266,7 +266,7 @@ class AddThis {
   private function setAnonymousProfileId() {
     $prefix = AddThis::ANONYMOUS_PROFILE_ID_PREFIX;
 
-    Global $base_url;
+    global $base_url;
     $regex = "/^(.*\/\/)(.*?)(\/.*)?$/";
     preg_match($regex, $base_url, $output_array);
     $domain = $output_array[2];

--- a/classes/AddThis.php
+++ b/classes/AddThis.php
@@ -253,6 +253,16 @@ class AddThis {
     return check_plain(variable_get(AddThis::PROFILE_ID_KEY));
   }
 
+  public function getAnonymousProfileId() {
+    $profile_id = check_plain(variable_get(AddThis::ANONYMOUS_PROFILE_ID_KEY));
+
+    if (!$profile_id) {
+      $profile_id = check_plain(AddThis::setAnonymousProfileId());
+    }
+
+    return $profile_id;
+  }
+
   private function setAnonymousProfileId() {
     $prefix = AddThis::ANONYMOUS_PROFILE_ID_PREFIX;
 

--- a/classes/AddThis.php
+++ b/classes/AddThis.php
@@ -277,6 +277,15 @@ class AddThis {
     return $profile_id;
   }
 
+  public function getUsableProfileId() {
+    $profile_id = $this->getProfileId();
+    if (!$profile_id) {
+        $profile_id = $this->getAnonymousProfileId();
+    }
+
+    return $profile_id;
+  }
+
   public function getServicesCssUrl() {
     return check_url(variable_get(AddThis::SERVICES_CSS_URL_KEY, self::DEFAULT_SERVICES_CSS_URL));
   }

--- a/classes/AddThis.php
+++ b/classes/AddThis.php
@@ -40,6 +40,7 @@ class AddThis {
   const FACEBOOK_LIKE_COUNT_SUPPORT_ENABLED = 'addthis_facebook_like_count_support_enabled';
   const OPEN_WINDOWS_ENABLED_KEY = 'addthis_open_windows_enabled';
   const PROFILE_ID_KEY = 'addthis_profile_id';
+  const ANONYMOUS_PROFILE_ID_KEY = 'addthis_anonymous_profile_id';
   const SERVICES_CSS_URL_KEY = 'addthis_services_css_url';
   const SERVICES_JSON_URL_KEY = 'addthis_services_json_url';
   const STANDARD_CSS_ENABLED_KEY = 'addthis_standard_css_enabled';
@@ -72,6 +73,7 @@ class AddThis {
   const WIDGET_JS_INCLUDE_PAGE = 1;
   const WIDGET_JS_INCLUDE_USAGE = 2;
 
+  const ANONYMOUS_PROFILE_ID_PREFIX = 'xa';
 
   // Internal resources.
   const ADMIN_CSS_FILE = 'addthis.admin.css';
@@ -249,6 +251,20 @@ class AddThis {
 
   public function getProfileId() {
     return check_plain(variable_get(AddThis::PROFILE_ID_KEY));
+  }
+
+  private function setAnonymousProfileId() {
+    $prefix = AddThis::ANONYMOUS_PROFILE_ID_PREFIX;
+
+    Global $base_url;
+    $regex = "/^(.*\/\/)(.*?)(\/.*)?$/";
+    preg_match($regex, $base_url, $output_array);
+    $domain = $output_array[2];
+    $postfix = hash_hmac('md5', $domain, 'addthis');
+
+    $profile_id = $prefix . '-' . $postfix;
+    variable_set(AddThis::ANONYMOUS_PROFILE_ID_PREFIX, $profile_id);
+    return $profile_id;
   }
 
   public function getServicesCssUrl() {

--- a/classes/Services/AddThisScriptManager.php
+++ b/classes/Services/AddThisScriptManager.php
@@ -100,7 +100,7 @@ class AddThisScriptManager {
     if ($this->addthis->getWidgetJsInclude() != AddThis::WIDGET_JS_INCLUDE_NONE) {
       $widget_js = new AddThisWidgetJsUrl($this->getWidgetJsUrl());
 
-      $pubid = $this->addthis->getProfileId();
+      $pubid = $this->addthis->getUsableProfileId();
       if (!empty($pubid) && is_string($pubid)) {
         $widget_js->addAttribute('pubid', $pubid);
       }
@@ -180,7 +180,7 @@ class AddThisScriptManager {
     $excluded_services = $this->addthis->getServiceNamesAsCommaSeparatedString($this->addthis->getExcludedServices());
 
     $configuration = array(
-      'pubid' => $this->addthis->getProfileId(),
+      'pubid' => $this->addthis->getUsableProfileId(),
       'services_compact' => $enabled_services,
       'services_exclude' => $excluded_services,
       'data_track_clickback' => $this->addthis->isClickbackTrackingEnabled(),


### PR DESCRIPTION
Using a consistent anonymous profile id allows AddThis support to migrate analytics to a normal ra-\* profile id if a user ever decides to sign up for an AddThis.com account for analytics or additional tools.
